### PR TITLE
Remove Room_ID from database schema & remove from codebase.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ for easy unit testing since each layer is independant of the other.
 
 ### Database Schema
 The following is an image of the database schema that is used for the web app.
-[![schema](https://user-images.githubusercontent.com/56979977/114913465-37922000-9def-11eb-9093-250cce0c6e86.png)](https://dbdiagram.io/d/606262f8ecb54e10c33dd900)
+[![schema](https://user-images.githubusercontent.com/56979977/115421799-494a3d80-a1ca-11eb-9a6b-975733597be2.png)](https://dbdiagram.io/d/606262f8ecb54e10c33dd900)
 
 ## TODO
 The project is still under development and is continually changing so here are a few things underworks
-- [x] Moving from MySQL to PostgreSQL.
-- [ ] Refactor the database schema to a better format.
+- [X] Moving from MySQL to PostgreSQL.
+- [X] Refactor the database schema to a better format.
 - [ ] Create REST endpoint documentation for the API
 - [ ] Host the API on a cloud platform (AWS or Heroku)
 

--- a/_sql/schema.sql
+++ b/_sql/schema.sql
@@ -1,7 +1,6 @@
 CREATE TABLE "rooms" (
-     "room_id" SERIAL PRIMARY KEY,
-     "host" varchar(100) NOT NULL,
-     "room_code" varchar(15) UNIQUE NOT NULL
+     "room_code" varchar(15) PRIMARY KEY,
+     "host" varchar(100) NOT NULL
 );
 
 CREATE TABLE "questions" (

--- a/domain/room.go
+++ b/domain/room.go
@@ -1,7 +1,6 @@
 package domain
 
 type Room struct {
-	RoomId   int    `json:"room_id"`
 	RoomCode string `json:"room_code"`
 	Host     string `json:"host"`
 }

--- a/handler/room_test.go
+++ b/handler/room_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestRoomHandler_GetRoom(t *testing.T) {
 	rs := new(mock.RoomService)
-	room := domain.Room{RoomId: 1, RoomCode: "jrHigh", Host: "Mat"}
+	room := domain.Room{RoomCode: "jrHigh", Host: "Mat"}
 	rs.On("FindRoom", "jrHigh").Return(room, nil)
 
 	w := httptest.NewRecorder()

--- a/infrastructure/postgres/questionstore_test.go
+++ b/infrastructure/postgres/questionstore_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestMySQLQuestionStore_GetById(t *testing.T) {
+func TestPostgresQuestionStore_GetById(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatal("There was an unexpected error when mocking the database.")
@@ -33,7 +33,7 @@ func TestMySQLQuestionStore_GetById(t *testing.T) {
 	assert.EqualValues(t, mQuestion, q)
 }
 
-func TestMySQLQuestionStore_GetAllForRoom(t *testing.T) {
+func TestPostgresQuestionStore_GetAllInRoom(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatal("There was an unexpected error when mocking the database.")
@@ -64,7 +64,7 @@ func TestMySQLQuestionStore_GetAllForRoom(t *testing.T) {
 	assert.EqualValues(t, qs, result)
 }
 
-func TestMySQLQuestionStore_UpdateLikeTotal(t *testing.T) {
+func TestPostgresQuestionStore_UpdateLikeTotal(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatal("there was an unexpected error when mocking the database.")
@@ -78,7 +78,7 @@ func TestMySQLQuestionStore_UpdateLikeTotal(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestMySQLQuestionStore_Create(t *testing.T) {
+func TestPostgresQuestionStore_Create(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatal("There was an unexpected error when mocking the database.")
@@ -98,7 +98,7 @@ func TestMySQLQuestionStore_Create(t *testing.T) {
 	assert.Equal(t, 1, mQuestion.QuestionId)
 }
 
-func TestMySQLQuestionStore_Delete(t *testing.T) {
+func TestPostgresQuestionStore_Delete(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatal("There was an unexpected error when mocking the database.")

--- a/infrastructure/postgres/roomstore.go
+++ b/infrastructure/postgres/roomstore.go
@@ -17,10 +17,10 @@ func NewRoomStore(db *sql.DB) domain.RoomStore {
 }
 
 func (p *postgresRoomStore) GetByRoomCode(code string) (domain.Room, error) {
-	row := p.db.QueryRow("SELECT room_id, host, room_code FROM rooms WHERE room_code = $1", code)
+	row := p.db.QueryRow("SELECT host, room_code FROM rooms WHERE room_code = $1", code)
 
 	var room domain.Room
-	err := row.Scan(&room.RoomId, &room.Host, &room.RoomCode)
+	err := row.Scan(&room.Host, &room.RoomCode)
 	if err != nil {
 		return domain.Room{}, err
 	}
@@ -28,13 +28,11 @@ func (p *postgresRoomStore) GetByRoomCode(code string) (domain.Room, error) {
 }
 
 func (p *postgresRoomStore) Create(room *domain.Room) error {
-	r, err := p.db.Exec("INSERT INTO rooms (host, room_code) VALUES ($1, $2)",
+	_, err := p.db.Exec("INSERT INTO rooms (host, room_code) VALUES ($1, $2)",
 		room.Host, room.RoomCode)
 	if err != nil {
 		return err
 	}
-	id, _ := r.LastInsertId()
-	room.RoomId = int(id)
 	return nil
 }
 

--- a/infrastructure/postgres/roomstore_test.go
+++ b/infrastructure/postgres/roomstore_test.go
@@ -7,20 +7,20 @@ import (
 	"testing"
 )
 
-func TestMySQLRoomStore_GetByRoomCode(t *testing.T) {
+func TestPostgresRoomStore_GetByRoomCode(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatal("There was an unexpected error when mocking the database.")
 	}
 
 	mockRoom := domain.Room{
-		RoomId: 1, RoomCode: "wantedCode", Host: "Mathew",
+		RoomCode: "wantedCode", Host: "Mathew",
 	}
 
-	row := sqlmock.NewRows([]string{"room_id", "host", "room_code"}).
-		AddRow(mockRoom.RoomId, mockRoom.Host, mockRoom.RoomCode)
+	row := sqlmock.NewRows([]string{"host", "room_code"}).
+		AddRow(mockRoom.Host, mockRoom.RoomCode)
 
-	query := "SELECT room_id, host, room_code FROM rooms WHERE room_code = ?"
+	query := "SELECT host, room_code FROM rooms WHERE room_code = ?"
 	mock.ExpectQuery(query).WithArgs("wantedCode").WillReturnRows(row)
 
 	m := NewRoomStore(db)
@@ -30,7 +30,7 @@ func TestMySQLRoomStore_GetByRoomCode(t *testing.T) {
 	assert.EqualValues(t, mockRoom, room)
 }
 
-func TestMySQLRoomStore_Create(t *testing.T) {
+func TestPostgresRoomStore_Create(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatal("There was an unexpected error when mocking the database.")
@@ -48,10 +48,9 @@ func TestMySQLRoomStore_Create(t *testing.T) {
 	m := NewRoomStore(db)
 	err = m.Create(room)
 	assert.NoError(t, err)
-	assert.Equal(t, 1, room.RoomId)
 }
 
-func TestMySQLRoomStore_Delete(t *testing.T) {
+func TestPostgresRoomStore_Delete(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatal("There was an unexpected error when mocking the database.")

--- a/service/roomservice_test.go
+++ b/service/roomservice_test.go
@@ -13,7 +13,7 @@ func TestRoomService_FindRoom(t *testing.T) {
 	rs := NewRoomService(store)
 
 	expectedRoom := domain.Room{
-		RoomId: 1, RoomCode: "room1", Host: "Mathew",
+		RoomCode: "room1", Host: "Mathew",
 	}
 	store.On("GetByRoomCode", "room1").Return(expectedRoom, nil)
 	room, err := rs.FindRoom("room1")


### PR DESCRIPTION
The Room_ID was not being used, since the room code is already the primary way of finding rooms and their associated question. Updated the schema to make the room code the new primary key and completely remove the room ID.