### PR TITLE
Change how DB is connected to use only one env variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,10 +26,8 @@ services:
       context: .
     container_name: Open-Stage
     environment:
-      DATABASE_PORT: '5432'
-      DATABASE_NAME: 'qa_platform'
-      DATABASE_USERNAME: 'admin'
-      DATABASE_PASSWORD: 'qa-password'
+      DATABASE_URL: 'postgres://admin:qa-password@127.0.0.1:5432/qa_platform'
+      SSL_DISABLED: true
       DATABASE_ADDRESS: db
     depends_on:
       db:

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"github.com/Mathew-Estafanous/Open-Stage/handler"
 	"github.com/Mathew-Estafanous/Open-Stage/infrastructure/postgres"
 	"github.com/Mathew-Estafanous/Open-Stage/service"
@@ -13,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 )
@@ -63,15 +63,13 @@ func main() {
 }
 
 func connectToDB() *sql.DB {
-	port := os.Getenv("DATABASE_PORT")
-	name := os.Getenv("DATABASE_NAME")
-	address := os.Getenv("DATABASE_ADDRESS")
-	user := os.Getenv("DATABASE_USERNAME")
-	pass := os.Getenv("DATABASE_PASSWORD")
+	dbUrl := os.Getenv("DATABASE_URL")
+	sslDisabled := os.Getenv("SSL_DISABLED")
+	if strings.ToLower(sslDisabled) == "true" {
+		dbUrl += "?sslmode=disable"
+	}
 
-	dsn := fmt.Sprintf("host=%v port=%v user=%v password=%v dbname=%v sslmode=disable", address, port, user, pass, name)
-	log.Println(dsn)
-	db, err := sql.Open("postgres", dsn)
+	db, err := sql.Open("postgres", dbUrl)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Connecting to the DB now requires one variable `DATABASE_URL` while there is an optional `SSL_DISABLED` env variable in the case that SSL does not want to be used for the app.