### PR TITLE
Setup frontend app for production deployment.

### DIFF
--- a/frontend/Procfile.txt
+++ b/frontend/Procfile.txt
@@ -1,0 +1,1 @@
+web: npm run prod

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "learn-react",
+  "name": "open-stage",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "learn-react",
+  "name": "open-stage",
   "version": "0.1.0",
   "private": true,
   "dependencies": {
@@ -13,10 +13,11 @@
     "web-vitals": "^1.1.1"
   },
   "scripts": {
-    "start": "./node_modules/.bin/react-scripts start",
-    "build": "./node_modules/.bin/react-scripts build",
-    "test": "./node_modules/.bin/react-scripts test",
-    "eject": "./node_modules/.bin/react-scripts eject"
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject",
+    "prod": "set REACT_APP_ENV=production&& react-scripts start"
   },
   "eslintConfig": {
     "extends": [

--- a/frontend/src/http/Questions.js
+++ b/frontend/src/http/Questions.js
@@ -1,4 +1,6 @@
-const url = 'http://localhost:8080/v1';
+const url = (process.env.REACT_APP_ENV === 'production')?
+    'https://open-stage-api.herokuapp.com/v1'
+    :'http://localhost:8080/v1';
 
 let questionsResponse = {
     body: [

--- a/frontend/src/http/Rooms.js
+++ b/frontend/src/http/Rooms.js
@@ -32,6 +32,7 @@ export const GetRoom = async (code) => {
             return response
         })
         .catch(err => {
+            console.log(err);
             response.error = 'We were unable to connect to our servers.';
             return response;
         })

--- a/frontend/src/http/Rooms.js
+++ b/frontend/src/http/Rooms.js
@@ -1,4 +1,6 @@
-const url = 'http://localhost:8080/v1';
+const url = (process.env.REACT_APP_ENV === 'production')?
+    'https://open-stage-api.herokuapp.com/v1'
+    :'http://localhost:8080/v1';
 
 const roomResponse = {
     body: {
@@ -28,5 +30,9 @@ export const GetRoom = async (code) => {
 
             response.body = {...data}
             return response
+        })
+        .catch(err => {
+            response.error = 'We were unable to connect to our servers.';
+            return response;
         })
 }


### PR DESCRIPTION
A deployment command for ``npm run prod`` will set up the react app in production mode and point to the production API endpoints instead of a local environment.