### PR TITLE
Change update like endpoint to take in an increment instead of new total like.

### DIFF
--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -106,22 +106,21 @@ definitions:
     x-go-package: github.com/Mathew-Estafanous/Open-Stage/domain
   updateLikes:
     properties:
+      like_increment:
+        description: Whether
+        example: -1
+        format: int64
+        type: integer
+        x-go-name: LikeIncrement
       question_id:
         description: The ID of the question
         example: 3452
         format: int64
         type: integer
         x-go-name: Id
-      total_likes:
-        description: New total likes for question
-        example: 2
-        format: int64
-        minimum: 0
-        type: integer
-        x-go-name: TotalLikes
     required:
     - question_id
-    - total_likes
+    - like_increment
     title: UpdateLike represents the question's new like total.
     type: object
     x-go-name: UpdateLike
@@ -165,7 +164,7 @@ paths:
       - Questions
     put:
       description: 'Updates the total # of likes for the question with the matching
-        question_id'
+        question_id.'
       operationId: updateLikes
       parameters:
       - in: body
@@ -174,7 +173,7 @@ paths:
           $ref: '#/definitions/updateLikes'
       responses:
         "200":
-          description: ' OK - Question''s like total has been updated.'
+          $ref: '#/responses/questionResponse'
         "400":
           $ref: '#/responses/errorResponse'
         "404":

--- a/backend/domain/mock/question.go
+++ b/backend/domain/mock/question.go
@@ -13,7 +13,7 @@ type QuestionService struct {
 
 func (m *QuestionService) ChangeTotalLikes(id int, total int) (domain.Question, error) {
 	ret := m.Called(id, total)
-	return ret.Get(0).(domain.Question) , ret.Error(1)
+	return ret.Get(0).(domain.Question), ret.Error(1)
 }
 
 func (m *QuestionService) FindWithId(id int) (domain.Question, error) {

--- a/backend/domain/mock/question.go
+++ b/backend/domain/mock/question.go
@@ -11,9 +11,9 @@ type QuestionService struct {
 	mock.Mock
 }
 
-func (m *QuestionService) ChangeTotalLikes(id int, total int) error {
+func (m *QuestionService) ChangeTotalLikes(id int, total int) (domain.Question, error) {
 	ret := m.Called(id, total)
-	return ret.Error(0)
+	return ret.Get(0).(domain.Question) , ret.Error(1)
 }
 
 func (m *QuestionService) FindWithId(id int) (domain.Question, error) {

--- a/backend/domain/question.go
+++ b/backend/domain/question.go
@@ -47,7 +47,7 @@ type QuestionStore interface {
 type QuestionService interface {
 	FindWithId(id int) (Question, error)
 	FindAllInRoom(code string) ([]Question, error)
-	ChangeTotalLikes(id int, total int) error
+	ChangeTotalLikes(id int, change int) (Question, error)
 	Create(q *Question) error
 	Delete(id int) error
 }

--- a/backend/handler/question.go
+++ b/backend/handler/question.go
@@ -105,7 +105,7 @@ func (q questionHandler) createQuestion(w http.ResponseWriter, r *http.Request) 
 // Updates the total # of likes for the question with the matching question_id.
 //
 // Responses:
-//  200: description: OK - Question's like total has been updated.
+//  200: questionResponse
 //  404: errorResponse
 //  400: errorResponse
 //  500: errorResponse

--- a/backend/handler/question.go
+++ b/backend/handler/question.go
@@ -18,12 +18,11 @@ type UpdateLike struct {
 	// example: 3452
 	Id int `json:"question_id"`
 
-	// New total likes for question
+	// Whether
 	//
 	// required: true
-	// min: 0
-	// example: 2
-	TotalLikes int `json:"total_likes"`
+	// example: -1
+	LikeIncrement int `json:"like_increment"`
 }
 
 // NewQuestion represents the request body of new questions.
@@ -103,7 +102,7 @@ func (q questionHandler) createQuestion(w http.ResponseWriter, r *http.Request) 
 //
 // Update question's total number of likes.
 //
-// Updates the total # of likes for the question with the matching question_id
+// Updates the total # of likes for the question with the matching question_id.
 //
 // Responses:
 //  200: description: OK - Question's like total has been updated.
@@ -118,11 +117,12 @@ func (q questionHandler) updateTotalLikes(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	err = q.qs.ChangeTotalLikes(body.Id, body.TotalLikes)
+	question, err := q.qs.ChangeTotalLikes(body.Id, body.LikeIncrement)
 	if err != nil {
 		q.error(w, err)
 		return
 	}
+	q.respond(w, http.StatusOK, question)
 }
 
 // swagger:route GET /questions/{roomCode} Questions roomCode

--- a/backend/handler/question_test.go
+++ b/backend/handler/question_test.go
@@ -74,6 +74,39 @@ func TestQuestionHandler_getAllQuestionInRoom(t *testing.T) {
 	assert.JSONEq(t, string(j), w.Body.String())
 }
 
+func TestQuestionHandler_updateTotalLikes(t *testing.T) {
+	qs := new(mock.QuestionService)
+
+	updatedQuestion := domain.Question{
+		QuestionId: 12,
+		Question:   "How is everyone doing?",
+		TotalLikes: 1,
+	}
+
+	qs.On("ChangeTotalLikes", 12, 1).Return(updatedQuestion, nil)
+
+	validBody := UpdateLike{
+		Id:            12,
+		LikeIncrement: 1,
+	}
+	j, err := json.Marshal(validBody)
+	assert.NoError(t, err)
+
+	req, err := http.NewRequest("PUT", "/questions", strings.NewReader(string(j)))
+	assert.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	r := mux.NewRouter()
+	NewQuestionHandler(qs).Route(r)
+	r.ServeHTTP(w, req)
+
+	j, err = json.Marshal(updatedQuestion)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, http.StatusOK, w.Code)
+	assert.JSONEq(t, string(j), w.Body.String())
+}
+
 func TestQuestionHandler_deleteQuestion(t *testing.T) {
 	qs := new(mock.QuestionService)
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -5,9 +5,9 @@ import (
 	"database/sql"
 	"github.com/Mathew-Estafanous/Open-Stage/handler"
 	"github.com/Mathew-Estafanous/Open-Stage/infrastructure/postgres"
+	"github.com/Mathew-Estafanous/Open-Stage/middleware"
 	"github.com/Mathew-Estafanous/Open-Stage/service"
-	"github.com/go-openapi/runtime/middleware"
-	"github.com/gorilla/handlers"
+	middle "github.com/go-openapi/runtime/middleware"
 	"github.com/gorilla/mux"
 	_ "github.com/lib/pq"
 	"log"
@@ -80,22 +80,19 @@ func connectToDB() *sql.DB {
 }
 
 func configureDocsRoute(router *mux.Router) {
-	opts := middleware.RedocOpts{
+	opts := middle.RedocOpts{
 		SpecURL: "/docs/swagger.yaml",
 		Title:   "Open-Stage API Docs",
 	}
-	doc := middleware.Redoc(opts, nil)
+	doc := middle.Redoc(opts, nil)
 	router.Handle("/docs", doc)
 	router.Handle("/docs/swagger.yaml", http.FileServer(http.Dir("./")))
 }
 
 func configureServer(r http.Handler, port string) *http.Server {
-	headerOpts := handlers.AllowedHeaders([]string{"X-Requested-With", "Content-Type"})
-	originOpts := handlers.AllowedOrigins([]string{"*"})
-	methodOpts := handlers.AllowedMethods([]string{"GET", "POST", "PUT", "DELETE", "OPTIONS"})
 	return &http.Server{
 		Addr:         port,
-		Handler:      handlers.CORS(originOpts, methodOpts, headerOpts)(r),
+		Handler:      middleware.CORS()(r),
 		ReadTimeout:  25 * time.Second,
 		WriteTimeout: 25 * time.Second,
 	}

--- a/backend/middleware/cors.go
+++ b/backend/middleware/cors.go
@@ -1,0 +1,14 @@
+package middleware
+
+import (
+	"github.com/gorilla/handlers"
+	"github.com/gorilla/mux"
+)
+
+// CORS is creates a middleware that will handle CORS for the API.
+func CORS() mux.MiddlewareFunc {
+	headerOpts := handlers.AllowedHeaders([]string{"X-Requested-With", "Content-Type"})
+	originOpts := handlers.AllowedOrigins([]string{"*"})
+	methodOpts := handlers.AllowedMethods([]string{"GET", "POST", "PUT", "DELETE", "OPTIONS"})
+	return handlers.CORS(headerOpts, originOpts, methodOpts)
+}

--- a/backend/service/question_test.go
+++ b/backend/service/question_test.go
@@ -63,21 +63,22 @@ func TestQuestionService_ChangeTotalLikes(t *testing.T) {
 	rService := new(mock.RoomService)
 	qs := NewQuestionService(qStore, rService)
 
-	qStore.On("UpdateLikeTotal", 12, 1).Return(nil)
-	qStore.On("GetById", 12).Return(domain.Question{}, nil)
-	err := qs.ChangeTotalLikes(12, 1)
+	qStore.On("UpdateLikeTotal", 12, 2).Return(nil)
+	qStore.On("GetById", 12).Return(domain.Question{TotalLikes: 1}, nil)
+	q, err := qs.ChangeTotalLikes(12, 1)
 	assert.NoError(t, err)
+	assert.EqualValues(t, 2, q.TotalLikes)
 
 	qStore.On("GetById", 20).Return(domain.Question{}, errQuestionNotFound)
-	err = qs.ChangeTotalLikes(20, 1)
+	_, err = qs.ChangeTotalLikes(20, 1)
 	assert.ErrorIs(t, err, errQuestionNotFound)
 
-	err = qs.ChangeTotalLikes(12, -1)
-	assert.ErrorIs(t, err, errTotalBelowZero)
+	_, err = qs.ChangeTotalLikes(12, -2)
+	assert.ErrorIs(t, err, errInvalidIncrement)
 
 	qStore.On("UpdateLikeTotal", 25, 1).Return(errors.New("some sql internal error"))
 	qStore.On("GetById", 25).Return(domain.Question{}, nil)
-	err = qs.ChangeTotalLikes(25, 1)
+	q, err = qs.ChangeTotalLikes(25, 1)
 	assert.ErrorIs(t, err, errInternalIssue)
 }
 

--- a/frontend/src/components/Question.jsx
+++ b/frontend/src/components/Question.jsx
@@ -31,13 +31,13 @@ export const Question = (prop) => {
     }
 
     const clickLike = async () => {
-        let likes = totalLikes + ((!liked)? 1: -1);
-        let result = await UpdateLikes(likes, prop.question_id);
-        if(result.status !== 200) {
+        let increment = (!liked)? 1: -1;
+        let result = await UpdateLikes(increment, prop.question_id);
+        if(result.error !== '') {
             console.log(result.error);
             return;
         }
-        setTotalLikes(likes);
+        setTotalLikes(result.body.total_likes);
         setLiked(!liked);
 
         updateLocalStorage();

--- a/frontend/src/http/Questions.js
+++ b/frontend/src/http/Questions.js
@@ -1,7 +1,7 @@
 const url = (process.env.REACT_APP_ENV === 'production')?
     'https://open-stage-api.herokuapp.com/v1' :'http://localhost:8080/v1';
 
-let questionsResponse = {
+let multipleQuestionResponse = {
     body: [
         {
             associated_room: '',
@@ -17,7 +17,7 @@ let questionsResponse = {
 export const GetAllQuestions = (code) => {
     let path = url + '/questions/' + code;
     console.log(path)
-    let response = {...questionsResponse}
+    let response = {...multipleQuestionResponse}
     return fetch(path)
         .then(resp => Promise.all([resp.ok, resp.json()]))
         .then(([ok, data]) => {
@@ -32,7 +32,7 @@ export const GetAllQuestions = (code) => {
     })
 }
 
-let postQuestionResponse = {
+let questionResponse = {
     body: {
         question_id: 0,
         associated_room: '',
@@ -40,7 +40,7 @@ let postQuestionResponse = {
         questioner_name: '',
         total_likes: 0
     },
-    err: ''
+    error: ''
 }
 
 export const PostQuestion = (roomCode, question, name) => {
@@ -53,7 +53,7 @@ export const PostQuestion = (roomCode, question, name) => {
         data.questioner_name = name;
     }
 
-    let response = {...postQuestionResponse}
+    let response = {...questionResponse}
     return fetch(path, {
             method: 'POST',
             headers: {
@@ -73,17 +73,14 @@ export const PostQuestion = (roomCode, question, name) => {
         })
 }
 
-export const UpdateLikes = (likes, id) => {
+export const UpdateLikes = (increment, id) => {
     let path = url + '/questions'
     let data = {
         question_id: id,
-        total_likes: likes
+        like_increment: increment
     }
 
-    let result = {
-        status: 200,
-        error: ''
-    };
+    let response = {...questionResponse}
     return fetch(path, {
             method: 'PUT',
             headers: {
@@ -91,12 +88,14 @@ export const UpdateLikes = (likes, id) => {
             },
             body: JSON.stringify(data)
         })
-        .then(resp => {
-            if(!resp.ok) {
-                let error = resp.json();
-                result.status = error.status;
-                result.error = error.message;
+        .then(resp => Promise.all([resp.ok, resp.json()]))
+        .then(([ok, data]) => {
+            if(!ok) {
+                response.error = data.message
+                return response
             }
-            return result;
+
+            response.body = data
+            return response
         })
 }


### PR DESCRIPTION
Previously the update-like endpoint would rely on the client to decide the new total likes. This approach is dangerous since the API is able to change the total like by more than 1. This is not ideal. Another issue is that 2 different clients might update the total likes at the same time, which means they are both unaware of the "new" like total.

The new approach will take in a ``like_increment`` of either 1 or -1 and the API will then calculate the new total and return it to the client as a response.