### PR TITLE
Move Http specific response error outside of the domain/service layer.

### DIFF
--- a/backend/docs/doc.go
+++ b/backend/docs/doc.go
@@ -50,7 +50,7 @@ type roomResponse struct {
 // swagger:response errorResponse
 type errorResponse struct {
 	// in: body
-	Body domain.ResponseError
+	Body handler.ResponseError
 }
 
 // swagger:parameters updateLikes

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -19,7 +19,7 @@ definitions:
         type: string
         x-go-name: TimeStamp
     type: object
-    x-go-package: github.com/Mathew-Estafanous/Open-Stage/domain
+    x-go-package: github.com/Mathew-Estafanous/Open-Stage/handler
   newQuestion:
     properties:
       associated_room:

--- a/backend/domain/response.go
+++ b/backend/domain/response.go
@@ -1,19 +1,23 @@
 package domain
 
-type ErrType int
+type Code int
 
 const (
-	BadInput ErrType = iota
+	Internal Code = iota
 	NotFound
 	Conflict
-	Internal
+	BadInput
 )
 
-type ApiError struct {
-	Msg string
-	Typ ErrType
-}
-
-func (e ApiError) Error() string {
-	return e.Msg
+func (c Code) Error() string {
+	switch c {
+	case BadInput:
+		return "Bad Input"
+	case NotFound:
+		return "Not Found"
+	case Conflict:
+		return "Conflict"
+	default:
+		return "Internal Error"
+	}
 }

--- a/backend/domain/response.go
+++ b/backend/domain/response.go
@@ -1,52 +1,19 @@
 package domain
 
-import (
-	"net/http"
-	"time"
+type ErrType int
+
+const (
+	BadInput ErrType = iota
+	NotFound
+	Conflict
+	Internal
 )
 
-type ResponseError struct {
-	// The server error message.
-	Msg string `json:"message"`
-	// The https status error.
-	Sts int `json:"status"`
-	// Time in which the error has occurred.
-	TimeStamp time.Time `json:"timestamp"`
+type ApiError struct {
+	Msg string
+	Typ ErrType
 }
 
-func (r ResponseError) Error() string {
-	return r.Msg
-}
-
-func NewResponseError(msg string, sts int) ResponseError {
-	return ResponseError{
-		Msg:       msg,
-		Sts:       sts,
-		TimeStamp: time.Now(),
-	}
-}
-
-func NotFound(msg string) ResponseError {
-	return NewResponseError(msg, http.StatusNotFound)
-}
-
-func InternalServerError(msg string) ResponseError {
-	if msg == "" {
-		msg = "We encountered an internal error while processing the request."
-	}
-	return NewResponseError(msg, http.StatusInternalServerError)
-}
-
-func BadRequest(msg string) ResponseError {
-	if msg == "" {
-		msg = "The given request was in a bad format."
-	}
-	return NewResponseError(msg, http.StatusBadRequest)
-}
-
-func Conflict(msg string) ResponseError {
-	if msg == "" {
-		msg = "There was a conflict while processing the request."
-	}
-	return NewResponseError(msg, http.StatusConflict)
+func (e ApiError) Error() string {
+	return e.Msg
 }

--- a/backend/handler/base_test.go
+++ b/backend/handler/base_test.go
@@ -19,9 +19,11 @@ func TestBaseHandler_error(t *testing.T) {
 
 	assert.EqualValues(t, w.Code, http.StatusBadRequest)
 
-	expectedResp, err := json.Marshal(newResponseError(respErr.Msg, http.StatusBadRequest))
+	var resp ResponseError
+	err := json.Unmarshal([]byte(w.Body.String()), &resp)
 	assert.NoError(t, err)
-	assert.JSONEq(t, string(expectedResp), w.Body.String())
+	assert.EqualValues(t, respErr.Msg, resp.Msg)
+	assert.EqualValues(t, http.StatusBadRequest, resp.Sts)
 
 	w = httptest.NewRecorder()
 	regErr := errors.New("this ia standard regular error")

--- a/backend/handler/base_test.go
+++ b/backend/handler/base_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"github.com/Mathew-Estafanous/Open-Stage/domain"
 	"github.com/stretchr/testify/assert"
 	"net/http"
@@ -14,7 +15,7 @@ func TestBaseHandler_error(t *testing.T) {
 	base := baseHandler{}
 
 	w := httptest.NewRecorder()
-	respErr := domain.ApiError{Msg: "Bad request", Typ: domain.BadInput}
+	respErr := fmt.Errorf("%w: bad request", domain.BadInput)
 	base.error(w, respErr)
 
 	assert.EqualValues(t, w.Code, http.StatusBadRequest)
@@ -22,7 +23,7 @@ func TestBaseHandler_error(t *testing.T) {
 	var resp ResponseError
 	err := json.Unmarshal([]byte(w.Body.String()), &resp)
 	assert.NoError(t, err)
-	assert.EqualValues(t, respErr.Msg, resp.Msg)
+	assert.EqualValues(t, respErr.Error(), resp.Msg)
 	assert.EqualValues(t, http.StatusBadRequest, resp.Sts)
 
 	w = httptest.NewRecorder()

--- a/backend/handler/base_test.go
+++ b/backend/handler/base_test.go
@@ -14,13 +14,14 @@ func TestBaseHandler_error(t *testing.T) {
 	base := baseHandler{}
 
 	w := httptest.NewRecorder()
-	respErr := domain.NewResponseError("A Bad request", http.StatusBadRequest)
+	respErr := domain.ApiError{Msg: "Bad request", Typ: domain.BadInput}
 	base.error(w, respErr)
-	j, err := json.Marshal(respErr)
-	assert.NoError(t, err)
 
-	assert.EqualValues(t, w.Code, respErr.Sts)
-	assert.JSONEq(t, string(j), w.Body.String())
+	assert.EqualValues(t, w.Code, http.StatusBadRequest)
+
+	expectedResp, err := json.Marshal(newResponseError(respErr.Msg, http.StatusBadRequest))
+	assert.NoError(t, err)
+	assert.JSONEq(t, string(expectedResp), w.Body.String())
 
 	w = httptest.NewRecorder()
 	regErr := errors.New("this ia standard regular error")

--- a/backend/handler/question.go
+++ b/backend/handler/question.go
@@ -161,7 +161,7 @@ func (q questionHandler) deleteQuestion(w http.ResponseWriter, r *http.Request) 
 
 	idInt, err := strconv.Atoi(id)
 	if err != nil {
-		err = domain.BadRequest("Given question Id is not a valid int type.")
+		err = domain.ApiError{Msg: "Given question Id is not a valid int type.", Typ: domain.BadInput}
 		q.error(w, err)
 		return
 	}

--- a/backend/handler/question.go
+++ b/backend/handler/question.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/Mathew-Estafanous/Open-Stage/domain"
 	"github.com/gorilla/mux"
 	"net/http"
@@ -161,7 +162,7 @@ func (q questionHandler) deleteQuestion(w http.ResponseWriter, r *http.Request) 
 
 	idInt, err := strconv.Atoi(id)
 	if err != nil {
-		err = domain.ApiError{Msg: "Given question Id is not a valid int type.", Typ: domain.BadInput}
+		err = fmt.Errorf("%w: given question id is not a valid int type", domain.BadInput)
 		q.error(w, err)
 		return
 	}

--- a/backend/handler/question_test.go
+++ b/backend/handler/question_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/Mathew-Estafanous/Open-Stage/domain"
 	"github.com/Mathew-Estafanous/Open-Stage/domain/mock"
 	"github.com/gorilla/mux"
@@ -38,7 +39,7 @@ func TestQuestionHandler_createQuestion(t *testing.T) {
 	j, err = json.Marshal(invalidQuestion)
 	assert.NoError(t, err)
 
-	qs.On("Create", &invalidQuestion).Return(domain.ApiError{Msg: "", Typ: domain.BadInput})
+	qs.On("Create", &invalidQuestion).Return(fmt.Errorf("%w: bad input", domain.BadInput))
 
 	req, err = http.NewRequest("POST", "/questions", strings.NewReader(string(j)))
 	assert.NoError(t, err)

--- a/backend/handler/question_test.go
+++ b/backend/handler/question_test.go
@@ -38,7 +38,7 @@ func TestQuestionHandler_createQuestion(t *testing.T) {
 	j, err = json.Marshal(invalidQuestion)
 	assert.NoError(t, err)
 
-	qs.On("Create", &invalidQuestion).Return(domain.BadRequest(""))
+	qs.On("Create", &invalidQuestion).Return(domain.ApiError{Msg: "", Typ: domain.BadInput})
 
 	req, err = http.NewRequest("POST", "/questions", strings.NewReader(string(j)))
 	assert.NoError(t, err)

--- a/backend/handler/room_test.go
+++ b/backend/handler/room_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/Mathew-Estafanous/Open-Stage/domain"
 	"github.com/Mathew-Estafanous/Open-Stage/domain/mock"
 	"github.com/gorilla/mux"
@@ -29,7 +30,7 @@ func TestRoomHandler_GetRoom(t *testing.T) {
 	assert.JSONEq(t, string(roomJson), w.Body.String())
 
 	rs.On("FindRoom", "wrongCode").
-		Return(domain.Room{}, domain.ApiError{Msg: "not found", Typ: domain.NotFound})
+		Return(domain.Room{}, fmt.Errorf("%w: not found", domain.NotFound))
 	req, err = http.NewRequest("GET", "/rooms/wrongCode", nil)
 	assert.NoError(t, err)
 
@@ -59,7 +60,7 @@ func TestRoomHandler_CreateRoom(t *testing.T) {
 	assert.JSONEq(t, string(j), w.Body.String())
 
 	duplicate := domain.Room{RoomCode: "duplicateCode", Host: "Mat"}
-	rs.On("CreateRoom", &duplicate).Return(domain.ApiError{Msg: "conflict", Typ: domain.Conflict})
+	rs.On("CreateRoom", &duplicate).Return(fmt.Errorf("%w: conflict", domain.Conflict))
 	j, err = json.Marshal(duplicate)
 	assert.NoError(t, err)
 
@@ -84,7 +85,7 @@ func TestRoomHandler_DeleteRoom(t *testing.T) {
 
 	assert.EqualValues(t, http.StatusOK, w.Code)
 
-	rs.On("DeleteRoom", "wrongCode").Return(domain.ApiError{Msg: "not found", Typ: domain.NotFound})
+	rs.On("DeleteRoom", "wrongCode").Return(fmt.Errorf("%w: not found", domain.NotFound))
 	w = httptest.NewRecorder()
 	req, err = http.NewRequest("DELETE", "/rooms/wrongCode", strings.NewReader(""))
 	assert.NoError(t, err)

--- a/backend/handler/room_test.go
+++ b/backend/handler/room_test.go
@@ -29,7 +29,7 @@ func TestRoomHandler_GetRoom(t *testing.T) {
 	assert.JSONEq(t, string(roomJson), w.Body.String())
 
 	rs.On("FindRoom", "wrongCode").
-		Return(domain.Room{}, domain.NotFound(""))
+		Return(domain.Room{}, domain.ApiError{Msg: "not found", Typ: domain.NotFound})
 	req, err = http.NewRequest("GET", "/rooms/wrongCode", nil)
 	assert.NoError(t, err)
 
@@ -59,7 +59,7 @@ func TestRoomHandler_CreateRoom(t *testing.T) {
 	assert.JSONEq(t, string(j), w.Body.String())
 
 	duplicate := domain.Room{RoomCode: "duplicateCode", Host: "Mat"}
-	rs.On("CreateRoom", &duplicate).Return(domain.Conflict(""))
+	rs.On("CreateRoom", &duplicate).Return(domain.ApiError{Msg: "conflict", Typ: domain.Conflict})
 	j, err = json.Marshal(duplicate)
 	assert.NoError(t, err)
 
@@ -84,7 +84,7 @@ func TestRoomHandler_DeleteRoom(t *testing.T) {
 
 	assert.EqualValues(t, http.StatusOK, w.Code)
 
-	rs.On("DeleteRoom", "wrongCode").Return(domain.NotFound(""))
+	rs.On("DeleteRoom", "wrongCode").Return(domain.ApiError{Msg: "not found", Typ: domain.NotFound})
 	w = httptest.NewRecorder()
 	req, err = http.NewRequest("DELETE", "/rooms/wrongCode", strings.NewReader(""))
 	assert.NoError(t, err)

--- a/backend/service/question.go
+++ b/backend/service/question.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"github.com/Mathew-Estafanous/Open-Stage/domain"
 )
 
@@ -86,10 +87,10 @@ func (q questionService) Delete(id int) error {
 }
 
 var (
-	errInvalidIncrement     = domain.ApiError{Msg: "The provided like increment is not 1 or -1.", Typ: domain.BadInput}
-	errQuestionNotFound     = domain.ApiError{Msg: "A question with that id was not found.", Typ: domain.NotFound}
-	errQuestionMustHaveRoom = domain.ApiError{Msg: "Every question must be assigned a room.", Typ: domain.BadInput}
-	errMissingQuestion      = domain.ApiError{Msg: "A question was not provided.", Typ: domain.BadInput}
-	errQuestionNotCreated   = domain.ApiError{Msg: "The question could not be created using the room code.", Typ: domain.BadInput}
-	errInternalIssue        = domain.ApiError{Msg: "We encountered an internal error", Typ: domain.Internal}
+	errInvalidIncrement     = fmt.Errorf("%w: the provided like increment is not 1 or -1", domain.BadInput)
+	errQuestionNotFound     = fmt.Errorf("%w: a question with that id was not found", domain.NotFound)
+	errQuestionMustHaveRoom = fmt.Errorf("%w: every question must be assigned a room", domain.BadInput)
+	errMissingQuestion      = fmt.Errorf("%w: a question was not provided", domain.BadInput)
+	errQuestionNotCreated   = fmt.Errorf("%w: the question could not be created using the room code", domain.BadInput)
+	errInternalIssue        = fmt.Errorf("%w: we encountered an internal error", domain.Internal)
 )

--- a/backend/service/question.go
+++ b/backend/service/question.go
@@ -86,10 +86,10 @@ func (q questionService) Delete(id int) error {
 }
 
 var (
-	errInvalidIncrement     = domain.BadRequest("The provided like increment is not 1 or -1.")
-	errQuestionNotFound     = domain.NotFound("A question with that id was not found.")
-	errQuestionMustHaveRoom = domain.BadRequest("Every question must be assigned a room.")
-	errMissingQuestion      = domain.BadRequest("A question was not provided.")
-	errQuestionNotCreated   = domain.BadRequest("The question could not be created using the room code.")
-	errInternalIssue        = domain.InternalServerError("")
+	errInvalidIncrement     = domain.ApiError{Msg: "The provided like increment is not 1 or -1.", Typ: domain.BadInput}
+	errQuestionNotFound     = domain.ApiError{Msg: "A question with that id was not found.", Typ: domain.NotFound}
+	errQuestionMustHaveRoom = domain.ApiError{Msg: "Every question must be assigned a room.", Typ: domain.BadInput}
+	errMissingQuestion      = domain.ApiError{Msg: "A question was not provided.", Typ: domain.BadInput}
+	errQuestionNotCreated   = domain.ApiError{Msg: "The question could not be created using the room code.", Typ: domain.BadInput}
+	errInternalIssue        = domain.ApiError{Msg: "We encountered an internal error", Typ: domain.Internal}
 )

--- a/backend/service/room.go
+++ b/backend/service/room.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"github.com/Mathew-Estafanous/Open-Stage/domain"
 	"math/rand"
 	"time"
@@ -67,8 +68,8 @@ func (r *roomService) generateValidCode() string {
 }
 
 var (
-	errHostNotAssigned = domain.ApiError{Msg: "A host has not be assigned to a room", Typ: domain.BadInput}
-	errDuplicateRoom   = domain.ApiError{Msg: "Room could not be created since the room code is taken.", Typ: domain.Conflict}
-	errRoomNotFound    = domain.ApiError{Msg: "Room was not found with given code", Typ: domain.NotFound}
-	errRoomNotDeleted  = domain.ApiError{Msg: "There was an error while trying to delete the room.", Typ: domain.Internal}
+	errHostNotAssigned = fmt.Errorf("%w: a host has not be assigned to a room", domain.BadInput)
+	errDuplicateRoom   = fmt.Errorf("%w: room could not be created since the room code is taken", domain.Conflict)
+	errRoomNotFound    = fmt.Errorf("%w: room was not found with given code", domain.NotFound)
+	errRoomNotDeleted  = fmt.Errorf("%w: we encountered an issue when trying to delete your room", domain.Internal)
 )

--- a/backend/service/room.go
+++ b/backend/service/room.go
@@ -67,8 +67,8 @@ func (r *roomService) generateValidCode() string {
 }
 
 var (
-	errHostNotAssigned = domain.BadRequest("A host has not be assigned to a room")
-	errDuplicateRoom   = domain.Conflict("Room could not be created since the room code is taken.")
-	errRoomNotFound    = domain.NotFound("Room was not found with given code")
-	errRoomNotDeleted  = domain.InternalServerError("There was an error while trying to delete the room.")
+	errHostNotAssigned = domain.ApiError{Msg: "A host has not be assigned to a room", Typ: domain.BadInput}
+	errDuplicateRoom   = domain.ApiError{Msg: "Room could not be created since the room code is taken.", Typ: domain.Conflict}
+	errRoomNotFound    = domain.ApiError{Msg: "Room was not found with given code", Typ: domain.NotFound}
+	errRoomNotDeleted  = domain.ApiError{Msg: "There was an error while trying to delete the room.", Typ: domain.Internal}
 )


### PR DESCRIPTION
After a great pairing session with Dmitry, we came to the idea that It might be best if my domain response error struct did not specify the HTTP status code. That way, my business logic can remain independent of external presentation layers.

The general idea is to have the service layers return API errors that specify the error message and the type of error, then the handler will deal with specifying the HTTP status code and creating the response body.