### PR TITLE
Enforce SSL

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -39,7 +39,7 @@ func main() {
 
 	port := portByProfile()
 	log.Printf("Open-Stage starting on port %v", port)
-	server := configureServer(router, port)
+	server := configureServer(middleware.CORS()(router), port)
 
 	go func() {
 		c := make(chan os.Signal)
@@ -92,7 +92,7 @@ func configureDocsRoute(router *mux.Router) {
 func configureServer(r http.Handler, port string) *http.Server {
 	return &http.Server{
 		Addr:         port,
-		Handler:      middleware.CORS()(r),
+		Handler:      middleware.EnforceSSL(r),
 		ReadTimeout:  25 * time.Second,
 		WriteTimeout: 25 * time.Second,
 	}

--- a/backend/middleware/ssl.go
+++ b/backend/middleware/ssl.go
@@ -1,0 +1,23 @@
+package middleware
+
+import (
+	"net/http"
+	"os"
+)
+
+// EnforceSSL will redirect all HTTP requests to HTTPS to ensure SSL security.
+// SSL is only enforced if the app is running in production. If not, regular http
+// requests will be accepted.
+func EnforceSSL(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if os.Getenv("PROFILE") == "prod" {
+			if r.Header.Get("x-forwarded-proto") != "https" {
+				sslUrl := "https://" + r.Host + r.RequestURI
+				http.Redirect(w, r, sslUrl, http.StatusTemporaryRedirect)
+				return
+			}
+		}
+
+		h.ServeHTTP(w, r)
+	})
+}


### PR DESCRIPTION
Added middleware that will enforce SSL when the app is running in production mode. Uses ``X-Forwarded-Proto`` header to determine whether the initial request was made through HTTP or HTTPS. If It is made through HTTP  then the request is redirected.