### PR TITLE
Alter Room endpoints to include Account ID

### DIFF
--- a/backend/docs/doc.go
+++ b/backend/docs/doc.go
@@ -11,6 +11,15 @@
 // License: MIT https://opensource.org/licenses/MIT
 // Contact: Mathew Estafanous<mathewestafanous13@gmail.com> https://mathewestafanous.com/
 //
+// Security:
+// - jwtAuth:
+//
+// SecurityDefinitions:
+// jwtAuth:
+//   type: apiKey
+//   name: Authorization
+//   in: header
+//
 // Consumes:
 // - application/json
 //

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -276,6 +276,8 @@ paths:
           $ref: '#/responses/errorResponse'
         "500":
           $ref: '#/responses/errorResponse'
+      security:
+      - jwtAuth: []
       summary: Delete an account by ID
       tags:
       - Accounts
@@ -476,4 +478,11 @@ responses:
       $ref: '#/definitions/room'
 schemes:
 - https
+security:
+- jwtAuth: []
+securityDefinitions:
+  jwtAuth:
+    in: header
+    name: Authorization
+    type: apiKey
 swagger: "2.0"

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -24,16 +24,24 @@ definitions:
     description: username, etc.
     properties:
       email:
+        description: Email associated with the account.
+        example: mathew@fake.com
         type: string
         x-go-name: Email
       id:
+        description: The account id.
+        example: 1234
         format: int64
         type: integer
         x-go-name: Id
       name:
+        description: Name of the account holder.
+        example: Mathew
         type: string
         x-go-name: Name
       username:
+        description: The account username.
+        example: MatMat2
         type: string
         x-go-name: Username
     title: AccountResp represents a user's account information like name,
@@ -57,17 +65,26 @@ definitions:
   createAccount:
     properties:
       email:
+        example: mathew@fake.com
         type: string
         x-go-name: Email
       name:
+        example: Mathew
         type: string
         x-go-name: Name
       password:
+        example: aSecretPassword
         type: string
         x-go-name: Password
       username:
+        example: MatMat
         type: string
         x-go-name: Username
+    required:
+    - name
+    - username
+    - password
+    - email
     title: CreateAccount are the fields that are used to signup a new user account.
     type: object
     x-go-name: CreateAccount
@@ -75,11 +92,18 @@ definitions:
   loginAccount:
     properties:
       password:
+        description: Password of the account.
+        example: aSecretPassword
         type: string
         x-go-name: Password
       username:
+        description: Username of the account wanted.
+        example: MatMat
         type: string
         x-go-name: Username
+    required:
+    - username
+    - password
     title: Login are the fields that are required to successfully log into an account.
     type: object
     x-go-name: Login
@@ -152,8 +176,14 @@ definitions:
       then contains questions that pertain to the room and whatever
       topic is in discussion.
     properties:
+      account_id:
+        description: The account that owns the room.
+        example: 3434
+        format: int64
+        type: integer
+        x-go-name: AccId
       host:
-        description: The host of the room.
+        description: The host of the room's name.
         example: Mathew
         type: string
         x-go-name: Host
@@ -164,6 +194,7 @@ definitions:
         x-go-name: RoomCode
     required:
     - host
+    - account_id
     title: Room models every group Q&A session/room.
     type: object
     x-go-name: Room

--- a/backend/domain/account.go
+++ b/backend/domain/account.go
@@ -8,15 +8,6 @@ type Account struct {
 	Email    string
 }
 
-// AuthToken contains both the access and refresh tokens after
-// a user has successfully authenticated.
-//
-// swagger:model authToken
-type AuthToken struct {
-	AccessToken  string `json:"access_token"`
-	RefreshToken string `json:"refresh_token"`
-}
-
 type AccountStore interface {
 	Create(acc *Account) error
 	GetByUsername(username string) (Account, error)

--- a/backend/domain/auth.go
+++ b/backend/domain/auth.go
@@ -1,0 +1,10 @@
+package domain
+
+// AuthToken contains both the access and refresh tokens after
+// a user has successfully authenticated.
+//
+// swagger:model authToken
+type AuthToken struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+}

--- a/backend/domain/room.go
+++ b/backend/domain/room.go
@@ -13,11 +13,17 @@ type Room struct {
 	// example: gopherCon
 	RoomCode string `json:"room_code"`
 
-	// The host of the room.
+	// The host of the room's name.
 	//
 	// required: true
 	// example: Mathew
 	Host string `json:"host"`
+
+	// The account that owns the room.
+	//
+	// required: true
+	// example: 3434
+	AccId int `json:"account_id"`
 }
 
 // RoomStore is an interface that describes the given contract

--- a/backend/handler/account.go
+++ b/backend/handler/account.go
@@ -14,27 +14,62 @@ import (
 //
 // swagger:model accountResponse
 type AccountResp struct {
-	Id       int    `json:"id"`
-	Name     string `json:"name"`
+	// The account id.
+	//
+	// example: 1234
+	Id int `json:"id"`
+
+	// Name of the account holder.
+	//
+	// example: Mathew
+	Name string `json:"name"`
+
+	// The account username.
+	//
+	// example: MatMat2
 	Username string `json:"username"`
-	Email    string `json:"email"`
+
+	// Email associated with the account.
+	//
+	// example: mathew@fake.com
+	Email string `json:"email"`
 }
 
 // CreateAccount are the fields that are used to signup a new user account.
 //
 // swagger:model createAccount
 type CreateAccount struct {
-	Name     string `json:"name"`
+	// required: true
+	// example: Mathew
+	Name string `json:"name"`
+
+	// required: true
+	// example: MatMat
 	Username string `json:"username"`
+
+	// required: true
+	// example: aSecretPassword
 	Password string `json:"password"`
-	Email    string `json:"email"`
+
+	// required: true
+	// example: mathew@fake.com
+	Email string `json:"email"`
 }
 
 // Login are the fields that are required to successfully log into an account.
 //
 // swagger:model loginAccount
 type Login struct {
+	// Username of the account wanted.
+	//
+	// required: true
+	// example: MatMat
 	Username string `json:"username"`
+
+	// Password of the account.
+	//
+	// required: true
+	// example: aSecretPassword
 	Password string `json:"password"`
 }
 
@@ -124,10 +159,10 @@ func (a accountHandler) createAccount(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := AccountResp{
-		Id: acc.Id,
-		Name: acc.Name,
+		Id:       acc.Id,
+		Name:     acc.Name,
 		Username: acc.Username,
-		Email: acc.Email,
+		Email:    acc.Email,
 	}
 	a.respond(w, http.StatusCreated, resp)
 }

--- a/backend/handler/account_test.go
+++ b/backend/handler/account_test.go
@@ -16,18 +16,18 @@ func TestAccountHandler_createAccount(t *testing.T) {
 	as := new(mock.AccountService)
 
 	account := domain.Account{
-		Name: "Mathew",
+		Name:     "Mathew",
 		Username: "MatMat",
 		Password: "ThisIsAPassword",
-		Email: "mathew@gmail.com",
+		Email:    "mathew@gmail.com",
 	}
 	as.On("Create", &account).Return(nil)
 
 	createAcc := CreateAccount{
-		Name: "Mathew",
+		Name:     "Mathew",
 		Username: "MatMat",
 		Password: "ThisIsAPassword",
-		Email: "mathew@gmail.com",
+		Email:    "mathew@gmail.com",
 	}
 
 	j, err := json.Marshal(createAcc)
@@ -42,10 +42,10 @@ func TestAccountHandler_createAccount(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	resp := AccountResp{
-		Id: 0,
-		Name: "Mathew",
+		Id:       0,
+		Name:     "Mathew",
 		Username: "MatMat",
-		Email: "mathew@gmail.com",
+		Email:    "mathew@gmail.com",
 	}
 	j, err = json.Marshal(resp)
 	assert.NoError(t, err)
@@ -53,12 +53,11 @@ func TestAccountHandler_createAccount(t *testing.T) {
 	assert.EqualValues(t, http.StatusCreated, w.Code)
 	assert.JSONEq(t, string(j), w.Body.String())
 
-
 	missingField := CreateAccount{
 		// Missing the 'name' field
 		Username: "MatMat",
 		Password: "ThisIsAPassword",
-		Email: "mathew@gmail.com",
+		Email:    "mathew@gmail.com",
 	}
 	j, err = json.Marshal(missingField)
 	assert.NoError(t, err)
@@ -85,7 +84,6 @@ func TestAccountHandler_deleteAccount(t *testing.T) {
 	NewAccountHandler(as).Route(r)
 	r.ServeHTTP(w, req)
 	assert.EqualValues(t, http.StatusOK, w.Code)
-
 
 	req, err = http.NewRequest("DELETE", "/accounts/sfaf", nil)
 	assert.NoError(t, err)

--- a/backend/handler/base.go
+++ b/backend/handler/base.go
@@ -49,10 +49,10 @@ func (h baseHandler) respond(w http.ResponseWriter, code int, src interface{}) {
 
 func errToHttpResp(err error) ResponseError {
 	errTypeToSts := map[domain.Code]int{
-		domain.Internal: http.StatusInternalServerError,
-		domain.NotFound: http.StatusNotFound,
-		domain.Conflict: http.StatusConflict,
-		domain.BadInput: http.StatusBadRequest,
+		domain.Internal:     http.StatusInternalServerError,
+		domain.NotFound:     http.StatusNotFound,
+		domain.Conflict:     http.StatusConflict,
+		domain.BadInput:     http.StatusBadRequest,
 		domain.Unauthorized: http.StatusUnauthorized,
 	}
 

--- a/backend/infrastructure/postgres/room.go
+++ b/backend/infrastructure/postgres/room.go
@@ -17,10 +17,10 @@ func NewRoomStore(db *sql.DB) domain.RoomStore {
 }
 
 func (p *postgresRoomStore) GetByRoomCode(code string) (domain.Room, error) {
-	row := p.db.QueryRow("SELECT host, room_code FROM rooms WHERE room_code = $1", code)
+	row := p.db.QueryRow("SELECT host, room_code, fk_account_id FROM rooms WHERE room_code = $1", code)
 
 	var room domain.Room
-	err := row.Scan(&room.Host, &room.RoomCode)
+	err := row.Scan(&room.Host, &room.RoomCode, &room.AccId)
 	if err != nil {
 		return domain.Room{}, err
 	}
@@ -28,8 +28,8 @@ func (p *postgresRoomStore) GetByRoomCode(code string) (domain.Room, error) {
 }
 
 func (p *postgresRoomStore) Create(room *domain.Room) error {
-	_, err := p.db.Exec("INSERT INTO rooms (host, room_code) VALUES ($1, $2)",
-		room.Host, room.RoomCode)
+	_, err := p.db.Exec("INSERT INTO rooms (host, room_code, fk_account_id) VALUES ($1, $2, $3)",
+		room.Host, room.RoomCode, room.AccId)
 	if err != nil {
 		return err
 	}

--- a/backend/infrastructure/postgres/room_test.go
+++ b/backend/infrastructure/postgres/room_test.go
@@ -14,13 +14,13 @@ func TestPostgresRoomStore_GetByRoomCode(t *testing.T) {
 	}
 
 	mockRoom := domain.Room{
-		RoomCode: "wantedCode", Host: "Mathew",
+		RoomCode: "wantedCode", Host: "Mathew", AccId: 1,
 	}
 
-	row := sqlmock.NewRows([]string{"host", "room_code"}).
-		AddRow(mockRoom.Host, mockRoom.RoomCode)
+	row := sqlmock.NewRows([]string{"host", "room_code", "fk_account_id"}).
+		AddRow(mockRoom.Host, mockRoom.RoomCode, mockRoom.AccId)
 
-	query := "SELECT host, room_code FROM rooms WHERE room_code = ?"
+	query := "SELECT host, room_code, fk_account_id FROM rooms WHERE room_code = ?"
 	mock.ExpectQuery(query).WithArgs("wantedCode").WillReturnRows(row)
 
 	m := NewRoomStore(db)
@@ -39,10 +39,11 @@ func TestPostgresRoomStore_Create(t *testing.T) {
 	room := &domain.Room{
 		RoomCode: "jrhigh",
 		Host:     "Mathew",
+		AccId: 1,
 	}
 
 	insertQuery := "INSERT INTO rooms"
-	mock.ExpectExec(insertQuery).WithArgs(room.Host, room.RoomCode).
+	mock.ExpectExec(insertQuery).WithArgs(room.Host, room.RoomCode, room.AccId).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	m := NewRoomStore(db)

--- a/backend/service/account_test.go
+++ b/backend/service/account_test.go
@@ -58,18 +58,18 @@ func TestAccountService_Authenticate(t *testing.T) {
 	aStore := new(mock.AccountStore)
 	service := NewAccountService(aStore)
 
-	acc := domain.Account{
+	respAcc := domain.Account{
 		Username: "someUsername",
 		// This is a hashed password 'helloWorld' using bcrypt.
 		Password: "$2y$12$UvUX39hRbeEGVCgEZmX3NO/5No10LEFe7ZsARJ5iK/55oSOUs7Bha",
 	}
-	aStore.On("GetByUsername", acc.Username).Return(acc, nil)
+	aStore.On("GetByUsername", respAcc.Username).Return(respAcc, nil)
 
-	auth := domain.Account{
+	acc := domain.Account{
 		Username: "someUsername",
 		Password: "helloWorld",
 	}
-	authToken, err := service.Authenticate(auth)
+	authToken, err := service.Authenticate(acc)
 	assert.NoError(t, err)
 
 	accessTkn, err := jwt.Parse(authToken.AccessToken, func(token *jwt.Token) (interface{}, error) {
@@ -85,8 +85,8 @@ func TestAccountService_Authenticate(t *testing.T) {
 	assert.EqualValues(t, true, accessTkn.Valid)
 	assert.EqualValues(t, true, refreshTkn.Valid)
 
-	auth.Username = "InvalidUsername"
-	aStore.On("GetByUsername", auth.Username).Return(domain.Account{}, domain.NotFound)
-	_, err = service.Authenticate(auth)
+	acc.Username = "InvalidUsername"
+	aStore.On("GetByUsername", acc.Username).Return(domain.Account{}, domain.NotFound)
+	_, err = service.Authenticate(acc)
 	assert.Error(t, err)
 }

--- a/backend/service/room.go
+++ b/backend/service/room.go
@@ -22,6 +22,10 @@ func (r *roomService) CreateRoom(room *domain.Room) error {
 		return errHostNotAssigned
 	}
 
+	if room.AccId == 0 {
+		return errMissingId
+	}
+
 	if room.RoomCode == "" {
 		room.RoomCode = r.generateValidCode()
 	}
@@ -72,4 +76,5 @@ var (
 	errDuplicateRoom   = fmt.Errorf("%w: room could not be created since the room code is taken", domain.Conflict)
 	errRoomNotFound    = fmt.Errorf("%w: room was not found with given code", domain.NotFound)
 	errRoomNotDeleted  = fmt.Errorf("%w: we encountered an issue when trying to delete your room", domain.Internal)
+	errMissingId       = fmt.Errorf("%w: missing the account id for the room", domain.BadInput)
 )

--- a/backend/service/room_test.go
+++ b/backend/service/room_test.go
@@ -33,19 +33,23 @@ func TestRoomService_CreateRoom(t *testing.T) {
 	store := new(mock.RoomStore)
 	rs := NewRoomService(store)
 
-	roomCreating := domain.Room{RoomCode: "room1", Host: "Mat"}
+	roomCreating := domain.Room{RoomCode: "room1", Host: "Mat", AccId: 1}
 	store.On("Create", &roomCreating).Return(nil)
 	err := rs.CreateRoom(&roomCreating)
 
 	assert.NoError(t, err)
 	store.AssertExpectations(t)
 
-	wrongRoom := domain.Room{RoomCode: "duplicateCode", Host: "Ja"}
+	wrongRoom := domain.Room{RoomCode: "duplicateCode", Host: "Ja", AccId: 1}
 	store.On("Create", &wrongRoom).Return(errDuplicateRoom)
 	err = rs.CreateRoom(&wrongRoom)
 
 	assert.ErrorIs(t, err, errDuplicateRoom)
 	store.AssertExpectations(t)
+
+	missingIdRoom := domain.Room{RoomCode: "room1", Host: "Mat"}
+	err = rs.CreateRoom(&missingIdRoom)
+	assert.ErrorIs(t, err, errMissingId)
 
 	err = rs.CreateRoom(&domain.Room{})
 	assert.ErrorIs(t, err, errHostNotAssigned)


### PR DESCRIPTION
The room endpoints for creating a room now will require an account ID so that each room is specifically owned by an account. Added documentation related to rooms and accounts as well.