### PR TITLE
Get account information with username endpoint

### DIFF
--- a/backend/docs/doc.go
+++ b/backend/docs/doc.go
@@ -140,3 +140,10 @@ type accountIdPath struct {
 	// in: path
 	ID string `json:"id"`
 }
+
+// swagger:parameters accountUsername
+type usernamePath struct {
+	// The account username
+	// in: path
+	Username string `json:"username"`
+}

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -269,6 +269,29 @@ paths:
       summary: Delete an account by ID
       tags:
       - Accounts
+  /accounts/{username}:
+    get:
+      description: Retrieve relevant account information by providing the username.
+      operationId: accountUsername
+      parameters:
+      - description: The account username
+        in: path
+        name: username
+        required: true
+        type: string
+        x-go-name: Username
+      responses:
+        "200":
+          $ref: '#/responses/accountResponse'
+        "403":
+          $ref: '#/responses/errorResponse'
+        "404":
+          $ref: '#/responses/errorResponse'
+        "500":
+          $ref: '#/responses/errorResponse'
+      summary: Get account information by username.
+      tags:
+      - Accounts
   /accounts/login:
     post:
       description: |-

--- a/backend/domain/account.go
+++ b/backend/domain/account.go
@@ -17,4 +17,5 @@ type AccountStore interface {
 type AccountService interface {
 	Create(acc *Account) error
 	Delete(id, accId int) error
+	FindByUsername(username string, accId int) (Account, error)
 }

--- a/backend/domain/mock/account.go
+++ b/backend/domain/mock/account.go
@@ -19,6 +19,11 @@ func (a *AccountService) Delete(id, accId int) error {
 	return ret.Error(0)
 }
 
+func (a *AccountService) FindByUsername(username string, accId int) (domain.Account, error) {
+	ret := a.Called(username, accId)
+	return ret.Get(0).(domain.Account), ret.Error(1)
+}
+
 type AccountStore struct {
 	mock.Mock
 }

--- a/backend/handler/account_test.go
+++ b/backend/handler/account_test.go
@@ -99,6 +99,37 @@ func TestAccountHandler_deleteAccount(t *testing.T) {
 	assert.EqualValues(t, http.StatusBadRequest, w.Code)
 }
 
+func TestAccountHandler_findWithUsername(t *testing.T) {
+	as := new(mock.AccountService)
+	auth := new(mock.AuthService)
+
+	acc := domain.Account{
+		Id: 5,
+		Username: "TheUsername",
+		Password: "SecretPassword",
+		Name: "Mathew",
+		Email: "mathew@fake.com",
+	}
+
+	j, err := json.Marshal(accountToResp(acc))
+	assert.NoError(t, err)
+
+	as.On("FindByUsername", "ThUsername", 5).Return(acc, nil)
+
+	req, err := http.NewRequest("GET", "/accounts/TheUsername", nil)
+	assert.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	r := mux.NewRouter()
+	secured := mock.SecureRouter(r, 5)
+	NewAccountHandler(as, auth).Route(r, secured)
+	r.ServeHTTP(w, req)
+
+
+	assert.EqualValues(t, http.StatusOK, w.Code)
+	assert.JSONEq(t, string(j), w.Body.String())
+}
+
 func TestAccountHandler_login(t *testing.T) {
 	as := new(mock.AccountService)
 	auth := new(mock.AuthService)

--- a/backend/handler/account_test.go
+++ b/backend/handler/account_test.go
@@ -114,7 +114,7 @@ func TestAccountHandler_findWithUsername(t *testing.T) {
 	j, err := json.Marshal(accountToResp(acc))
 	assert.NoError(t, err)
 
-	as.On("FindByUsername", "ThUsername", 5).Return(acc, nil)
+	as.On("FindByUsername", "TheUsername", 5).Return(acc, nil)
 
 	req, err := http.NewRequest("GET", "/accounts/TheUsername", nil)
 	assert.NoError(t, err)

--- a/backend/main.go
+++ b/backend/main.go
@@ -95,7 +95,7 @@ func configureDocsRoute(router *mux.Router) {
 	}
 	doc := middle.Redoc(opts, nil)
 	router.Handle("/docs", doc)
-	router.Handle("/docs/swagger.yaml", http.FileServer(http.Dir("./backend")))
+	router.Handle("/docs/swagger.yaml", http.FileServer(http.Dir("./")))
 }
 
 func configureServer(r http.Handler, port string) *http.Server {

--- a/backend/main.go
+++ b/backend/main.go
@@ -95,7 +95,7 @@ func configureDocsRoute(router *mux.Router) {
 	}
 	doc := middle.Redoc(opts, nil)
 	router.Handle("/docs", doc)
-	router.Handle("/docs/swagger.yaml", http.FileServer(http.Dir("./")))
+	router.Handle("/docs/swagger.yaml", http.FileServer(http.Dir("./backend")))
 }
 
 func configureServer(r http.Handler, port string) *http.Server {

--- a/backend/service/account.go
+++ b/backend/service/account.go
@@ -48,6 +48,18 @@ func (a *accountService) Delete(id, accId int) error {
 	return nil
 }
 
+func (a *accountService) FindByUsername(username string, accId int) (domain.Account, error) {
+	acc, err := a.store.GetByUsername(username)
+	if err != nil {
+		return domain.Account{}, err
+	}
+
+	if acc.Id != accId {
+		return domain.Account{}, fmt.Errorf("%w: account cannot be accessed with provided credentials", domain.Forbidden)
+	}
+	return acc, nil
+}
+
 var emailRegex = regexp.MustCompile(
 	"^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
 

--- a/backend/service/account_test.go
+++ b/backend/service/account_test.go
@@ -51,3 +51,29 @@ func TestAccountService_Delete(t *testing.T) {
 	err = service.Delete(1, 0)
 	assert.ErrorIs(t, err, domain.Forbidden)
 }
+
+func TestAccountService_FindByUsername(t *testing.T) {
+	aStore := new(mock.AccountStore)
+	service := NewAccountService(aStore)
+
+	acc := domain.Account{
+		Id: 10,
+		Username: "TheUsername",
+		Name: "Jackson",
+		Password: "A-PASSWORD",
+		Email: "jackson@fake.com",
+	}
+	aStore.On("GetByUsername", acc.Username).Return(acc, nil)
+
+	account, err := service.FindByUsername(acc.Username, acc.Id)
+	assert.NoError(t, err)
+	assert.EqualValues(t, acc, account)
+
+	aStore.On("GetByUsername", "invalidUsername").Return(domain.Account{}, domain.NotFound)
+
+	_, err = service.FindByUsername("invalidUsername", acc.Id)
+	assert.ErrorIs(t, err, domain.NotFound)
+
+	_, err = service.FindByUsername(acc.Username, 1)
+	assert.ErrorIs(t, err, domain.Forbidden)
+}


### PR DESCRIPTION
New GET endpoint ``/accounts/{username}`` that will retrieve all the relevant account information for that username. The client can only retrieve information from the account it is authenticated with.