### PR TITLE
API Endpoint for getting all rooms owned by a specific account.

### DIFF
--- a/backend/docs/doc.go
+++ b/backend/docs/doc.go
@@ -62,6 +62,13 @@ type accountResponse struct {
 	Body handler.AccountResp
 }
 
+// List of Q&A rooms.
+// swagger:response multiRoomResponse
+type multiRoomResponse struct {
+	// in: body
+	Body []domain.Room
+}
+
 // Both access and refresh tokens.
 // swagger:response authToken
 type tokenResponse struct {
@@ -146,4 +153,11 @@ type usernamePath struct {
 	// The account username
 	// in: path
 	Username string `json:"username"`
+}
+
+// swagger:parameters authHeader
+type authHeader struct {
+	// in: header
+	// example: Bearer [your-token]
+	Header string `json:"Authorization"`
 }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -506,6 +506,26 @@ paths:
       summary: Get room by code.
       tags:
       - Rooms
+  /rooms/all:
+    get:
+      description: |-
+        Finds all the rooms that are owned by the account. The associated account will be
+        dependant on the access token identifier, since this route is secured.
+      operationId: authHeader
+      parameters:
+      - example: Bearer [your-token]
+        in: header
+        name: Authorization
+        type: string
+        x-go-name: Header
+      responses:
+        "200":
+          $ref: '#/responses/multiRoomResponse'
+        "500":
+          $ref: '#/responses/errorResponse'
+      summary: Get all rooms associated with account.
+      tags:
+      - Rooms
 produces:
 - application/json
 responses:
@@ -526,6 +546,12 @@ responses:
     schema:
       items:
         $ref: '#/definitions/question'
+      type: array
+  multiRoomResponse:
+    description: List of Q&A rooms.
+    schema:
+      items:
+        $ref: '#/definitions/room'
       type: array
   questionResponse:
     description: A question that has been posted within a room.

--- a/backend/domain/mock/room.go
+++ b/backend/domain/mock/room.go
@@ -25,6 +25,11 @@ func (m *RoomService) DeleteRoom(code string, accId int) error {
 	return ret.Error(0)
 }
 
+func (m *RoomService) AllRoomsWithId(accId int) ([]domain.Room, error) {
+	ret := m.Called(accId)
+	return ret.Get(0).([]domain.Room), ret.Error(1)
+}
+
 // RoomStore is a mock struct that is used in unit tests.
 type RoomStore struct {
 	mock.Mock

--- a/backend/domain/mock/room.go
+++ b/backend/domain/mock/room.go
@@ -44,3 +44,8 @@ func (m *RoomStore) Delete(code string) error {
 	ret := m.Called(code)
 	return ret.Error(0)
 }
+
+func (m *RoomStore) FindAllRooms(accId int) ([]domain.Room, error) {
+	ret := m.Called(accId)
+	return ret.Get(0).([]domain.Room),  ret.Error(1)
+}

--- a/backend/domain/room.go
+++ b/backend/domain/room.go
@@ -38,4 +38,5 @@ type RoomService interface {
 	DeleteRoom(code string, accId int) error
 	CreateRoom(room *Room) error
 	FindRoom(roomCode string) (Room, error)
+	AllRoomsWithId(accId int) ([]Room, error)
 }

--- a/backend/domain/room.go
+++ b/backend/domain/room.go
@@ -31,6 +31,7 @@ type RoomStore interface {
 	Delete(roomCode string) error
 	GetByRoomCode(code string) (Room, error)
 	Create(room *Room) error
+	FindAllRooms(accId int) ([]Room, error)
 }
 
 type RoomService interface {

--- a/backend/handler/room.go
+++ b/backend/handler/room.go
@@ -21,6 +21,7 @@ func (r roomHandler) Route(ro, secured *mux.Router) {
 	ro.HandleFunc("/rooms/{code}", r.getRoom).Methods("GET")
 
 	secured.HandleFunc("/rooms", r.createRoom).Methods("POST")
+	secured.HandleFunc("/rooms/all", r.getAllRooms).Methods("GET")
 	secured.HandleFunc("/rooms/{code}", r.deleteRoom).Methods("DELETE")
 }
 
@@ -101,4 +102,29 @@ func (r roomHandler) deleteRoom(w http.ResponseWriter, re *http.Request) {
 	if err != nil {
 		r.error(w, err)
 	}
+}
+
+// swagger:route GET /rooms/all Rooms authHeader
+//
+// Get all rooms associated with account.
+//
+// Finds all the rooms that are owned by the account. The associated account will be
+// dependant on the access token identifier, since this route is secured.
+//
+// Responses:
+//  200: multiRoomResponse
+//  500: errorResponse
+func (r roomHandler) getAllRooms(w http.ResponseWriter, re *http.Request) {
+	accId, err := strconv.Atoi(re.Header.Get("Account"))
+	if err != nil {
+		r.error(w, err)
+		return
+	}
+
+	rooms, err := r.rs.AllRoomsWithId(accId)
+	if err != nil {
+		r.error(w, err)
+		return
+	}
+	r.respond(w, http.StatusOK, rooms)
 }

--- a/backend/handler/room_test.go
+++ b/backend/handler/room_test.go
@@ -99,3 +99,37 @@ func TestRoomHandler_DeleteRoom(t *testing.T) {
 
 	assert.EqualValues(t, http.StatusNotFound, w.Code)
 }
+
+func TestRoomHandler_GetAllRooms(t *testing.T) {
+	rs := new(mock.RoomService)
+
+	result := []domain.Room {
+		{
+			Host: "Mat",
+			RoomCode: "ARoomCode",
+			AccId: 1,
+		},
+		{
+			Host: "Mat",
+			RoomCode: "AnotherRoom",
+			AccId: 1,
+		},
+	}
+	rs.On("AllRoomsWithId", 1).Return(result, nil)
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/rooms/all", nil)
+	assert.NoError(t, err)
+	req.Header.Set("Account", strconv.Itoa(1))
+
+	r := mux.NewRouter()
+	secured := mock.SecureRouter(r, 1)
+	NewRoomHandler(rs).Route(r, secured)
+	r.ServeHTTP(w, req)
+
+	j, err := json.Marshal(result)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, http.StatusOK, w.Code)
+	assert.JSONEq(t, string(j), w.Body.String())
+}

--- a/backend/infrastructure/postgres/room.go
+++ b/backend/infrastructure/postgres/room.go
@@ -47,3 +47,22 @@ func (p *postgresRoomStore) Delete(roomCode string) error {
 	}
 	return nil
 }
+
+func (p *postgresRoomStore) FindAllRooms(accId int) ([]domain.Room, error) {
+	rows, err := p.db.Query("SELECT host, room_code, fk_account_id FROM rooms WHERE fk_account_id = $1", accId)
+	if err != nil {
+		return nil, err
+	}
+
+	var rooms []domain.Room
+	for rows.Next() {
+		var r domain.Room
+		err = rows.Scan(&r.Host, &r.RoomCode, &r.AccId)
+		if err != nil {
+			return nil, err
+		}
+		rooms = append(rooms, r)
+	}
+	return rooms, nil
+}
+

--- a/backend/infrastructure/postgres/room_test.go
+++ b/backend/infrastructure/postgres/room_test.go
@@ -71,3 +71,27 @@ func TestPostgresRoomStore_Delete(t *testing.T) {
 	err = m.Delete("wrongCode")
 	assert.Error(t, err)
 }
+
+func TestPostgresRoomStore_FindAllRooms(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal("There was an unexpected error when mocking the database.")
+	}
+
+	result := []domain.Room {
+		{
+			Host: "Mat",
+			RoomCode: "ARoomCode",
+			AccId: 1,
+		},
+	}
+
+	mock.ExpectQuery("SELECT host, room_code, fk_account_id FROM rooms").WithArgs(1).
+		WillReturnRows(sqlmock.NewRows([]string{"host", "room_code", "fk_account_id"}).
+			AddRow("Mat", "ARoomCode", 1))
+
+	m := NewRoomStore(db)
+	rooms, err := m.FindAllRooms(1)
+	assert.NoError(t, err)
+	assert.EqualValues(t, result, rooms)
+}

--- a/backend/service/room.go
+++ b/backend/service/room.go
@@ -11,7 +11,7 @@ type roomService struct {
 	rStore domain.RoomStore
 }
 
-func NewRoomService(rs domain.RoomStore) domain.RoomService {
+func NewRoomService(rs domain.RoomStore) *roomService {
 	return &roomService{
 		rStore: rs,
 	}
@@ -56,6 +56,14 @@ func (r *roomService) DeleteRoom(code string, accId int) error {
 		return errRoomNotDeleted
 	}
 	return nil
+}
+
+func (r *roomService) AllRoomsWithId(accId int) ([]domain.Room, error) {
+	rooms, err := r.rStore.FindAllRooms(accId)
+	if err != nil {
+		return nil, err
+	}
+	return rooms, nil
 }
 
 func (r *roomService) generateValidCode() string {

--- a/backend/service/room_test.go
+++ b/backend/service/room_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"fmt"
 	"github.com/Mathew-Estafanous/Open-Stage/domain"
 	"github.com/Mathew-Estafanous/Open-Stage/domain/mock"
 	"github.com/stretchr/testify/assert"
@@ -72,4 +73,32 @@ func TestRoomService_DeleteRoom(t *testing.T) {
 
 	err = rs.DeleteRoom("validCode", 3)
 	assert.ErrorIs(t, err, domain.Forbidden)
+}
+
+func TestRoomService_AllRoomsWithId(t *testing.T) {
+	store := new(mock.RoomStore)
+	rs := NewRoomService(store)
+
+	result := []domain.Room {
+		{
+			Host: "Mat",
+			RoomCode: "ACode",
+			AccId: 1,
+		},
+		{
+			Host: "Mat",
+			RoomCode: "AnotherCode",
+			AccId: 1,
+		},
+	}
+	store.On("FindAllRooms", 1).Return(result, nil)
+
+	rooms, err := rs.AllRoomsWithId(1)
+	assert.NoError(t, err)
+	assert.EqualValues(t, result, rooms)
+
+	store.On("FindAllRooms", 2).
+		Return([]domain.Room{}, fmt.Errorf("%w: connection error", domain.Internal))
+	_, err = rs.AllRoomsWithId(2)
+	assert.Error(t, err)
 }


### PR DESCRIPTION
Made a secured GET request under the ``/rooms/all`` endpoint. The endpoint will use the provided access token to identify the account and returns a list of all the rooms associated with that account.